### PR TITLE
Use cached image for VM/bootstrap

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,5 @@
 FROM quay.io/higginsd/resource-downloader
 
-RUN yum install -y epel-release && yum install -y qemu-img jq && yum clean all
+RUN yum install -y epel-release && yum install -y qemu-img jq iproute virt-what && yum clean all
 
 COPY ./get-resource.sh /usr/local/bin/get-resource.sh
-
-


### PR DESCRIPTION
This adds a check so that when we're running on a VM, we look for
a cached copy of the compressed file on the default route, which
will be the libvirt or baremetal bridge.

Then we can run the *downloader/httpd containers on the host via
dev-scripts to make testing much faster and more efficient in terms
of bandwidth, but in all other cases we download from the internet
as before.