### PR TITLE
Remove 'sleep infinity'

### DIFF
--- a/get-resource.sh
+++ b/get-resource.sh
@@ -56,5 +56,3 @@ if [ -s "${RHCOS_IMAGE_FILENAME_OPENSTACK}" ] ; then
 else
     rm -rf $TMPDIR
 fi
-
-sleep infinity


### PR DESCRIPTION
We want to use this as part of an 'init' container in kubernetes
so we want it to exit when it completes.