### PR TITLE
Handle a fully-qualified openstack qcow URL

### DIFF
--- a/get-resource.sh
+++ b/get-resource.sh
@@ -8,10 +8,21 @@ if [ -z "$RHCOS_IMAGE_URL" ] ; then
     exit 1
 fi
 
-RHCOS_IMAGE_FILENAME_OPENSTACK_GZ="$(curl ${RHCOS_IMAGE_URL}/meta.json | jq -r '.images.openstack.path')"
-RHCOS_IMAGE_NAME=$(echo $RHCOS_IMAGE_FILENAME_OPENSTACK_GZ | sed -e 's/-openstack.*//')
-RHCOS_IMAGE_FILENAME_OPENSTACK="${RHCOS_IMAGE_NAME}-openstack.qcow2"
-RHCOS_IMAGE_FILENAME_COMPRESSED="${RHCOS_IMAGE_NAME}-compressed.qcow2"
+# When provided by openshift-installer the URL is like
+# "https://releases-art-rhcos.svc.ci.openshift.org/art/storage/releases/rhcos-4.2/420.8.20190708.2/rhcos-420.8.20190708.2-openstack.qcow2"
+# In this case we use the URL as-is, otherwise for backwards compatibility
+# we figure it out from meta.json (when only the baseURI is provided)
+# The latter will be removed when 
+# https://github.com/openshift/installer/issues/2064 and
+# https://github.com/openshift/installer/issues/2037 are fully completed
+if [[ $RHCOS_IMAGE_URL = *.qcow2 ]]; then
+    RHCOS_IMAGE_FILENAME_OPENSTACK=$(basename $RHCOS_IMAGE_URL)
+    IMAGE_URL=$(dirname $RHCOS_IMAGE_URL)
+else
+    RHCOS_IMAGE_FILENAME_OPENSTACK="$(curl ${RHCOS_IMAGE_URL}/meta.json | jq -r '.images.openstack.path')"
+    IMAGE_URL=${RHCOS_IMAGE_URL}
+fi
+RHCOS_IMAGE_FILENAME_COMPRESSED=${RHCOS_IMAGE_FILENAME_OPENSTACK/%openstack.qcow2/compressed.qcow2}
 FFILENAME="rhcos-ootpa-latest.qcow2"
 
 mkdir -p /shared/html/images
@@ -41,7 +52,7 @@ if [ "$FILECACHED" == "${RHCOS_IMAGE_FILENAME_OPENSTACK}" ] ; then
     curl -O "$CACHEURL/$RHCOS_IMAGE_FILENAME_OPENSTACK/$RHCOS_IMAGE_FILENAME_OPENSTACK"
     curl -O "$CACHEURL/$RHCOS_IMAGE_FILENAME_OPENSTACK/$RHCOS_IMAGE_FILENAME_COMPRESSED.md5sum"
 else
-    curl --insecure --compressed -L --dump-header "${RHCOS_IMAGE_FILENAME_OPENSTACK}.headers" -o "${RHCOS_IMAGE_FILENAME_OPENSTACK}" "${RHCOS_IMAGE_URL}/${RHCOS_IMAGE_FILENAME_OPENSTACK}"
+    curl --insecure --compressed -L --dump-header "${RHCOS_IMAGE_FILENAME_OPENSTACK}.headers" -o "${RHCOS_IMAGE_FILENAME_OPENSTACK}" "${IMAGE_URL}/${RHCOS_IMAGE_FILENAME_OPENSTACK}"
     qemu-img convert -O qcow2 -c "$RHCOS_IMAGE_FILENAME_OPENSTACK" "$RHCOS_IMAGE_FILENAME_COMPRESSED"
     md5sum "$RHCOS_IMAGE_FILENAME_COMPRESSED" | cut -f 1 -d " " > "$RHCOS_IMAGE_FILENAME_COMPRESSED.md5sum"
 fi


### PR DESCRIPTION
The URL provided internally by the installer is the full path
to the openstack qcow file, and the baseURI is supposed to be an
internal detail, so we need to handle this case for the planned
switch to use installer generated image references:

https://github.com/openshift/installer/issues/2037
https://github.com/openshift/installer/pull/2061

The previous baseURI method is maintained for backwards compatibilty
and can be removed later when the installer changes are complete,
and at that point we probably want to remove the latest symlinks
as I think we need to deal with explicit image references in the
providerSpec, then have the BMO (and terraform) look at the mirror
location for the locally downloaded/compressed version.